### PR TITLE
chore: hygiene tick — coverage, dependabot, shell completions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/Moscow
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+      include: scope
+    groups:
+      go-deps:
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/Moscow
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(ci)"
+      include: scope
+    groups:
+      gh-actions:
+        patterns:
+          - "*"

--- a/.gitignore
+++ b/.gitignore
@@ -51,5 +51,6 @@ tags
 dist/
 plans/
 cover.out
+completions/
 # End of https://www.toptal.com/developers/gitignore/api/idea,vim,go
 .task/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -5,6 +5,10 @@ project_name: go-monkill
 before:
   hooks:
     - go mod tidy
+    - mkdir -p completions
+    - sh -c "go run . completion bash > completions/go-monkill.bash"
+    - sh -c "go run . completion zsh  > completions/go-monkill.zsh"
+    - sh -c "go run . completion fish > completions/go-monkill.fish"
 
 builds:
   - id: go-monkill
@@ -39,6 +43,7 @@ archives:
     files:
       - LICENSE
       - README.md
+      - completions/*
 
 checksum:
   name_template: "checksums.txt"
@@ -108,3 +113,6 @@ brews:
       system "#{bin}/go-monkill", "version"
     install: |
       bin.install "go-monkill"
+      bash_completion.install "completions/go-monkill.bash" => "go-monkill"
+      zsh_completion.install  "completions/go-monkill.zsh"  => "_go-monkill"
+      fish_completion.install "completions/go-monkill.fish"

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,92 @@
+package cmd
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestNewLoggerVerboseLevel(t *testing.T) {
+	t.Cleanup(resetGlobals)
+	Verbose = true
+	Logfile = ""
+
+	l, closer, err := newLogger()
+	if err != nil {
+		t.Fatalf("newLogger: %v", err)
+	}
+	defer func() { _ = closer.Close() }()
+
+	if l.GetLevel() != logrus.DebugLevel {
+		t.Fatalf("level = %v, want Debug", l.GetLevel())
+	}
+}
+
+func TestNewLoggerInfoLevelByDefault(t *testing.T) {
+	t.Cleanup(resetGlobals)
+	Verbose = false
+	Logfile = ""
+
+	l, closer, err := newLogger()
+	if err != nil {
+		t.Fatalf("newLogger: %v", err)
+	}
+	defer func() { _ = closer.Close() }()
+
+	if l.GetLevel() != logrus.InfoLevel {
+		t.Fatalf("level = %v, want Info", l.GetLevel())
+	}
+}
+
+func TestNewLoggerWritesJSONToFile(t *testing.T) {
+	t.Cleanup(resetGlobals)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "monkill.log")
+
+	Verbose = false
+	Logfile = path
+
+	l, closer, err := newLogger()
+	if err != nil {
+		t.Fatalf("newLogger: %v", err)
+	}
+	// Avoid polluting the test runner's stderr.
+	l.SetOutput(io.Discard)
+
+	l.Info("hello-from-test")
+	if err := closer.Close(); err != nil {
+		t.Fatalf("closer.Close: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read logfile: %v", err)
+	}
+	got := string(data)
+	if !strings.Contains(got, `"msg":"hello-from-test"`) {
+		t.Fatalf("logfile missing JSON entry; got: %s", got)
+	}
+	if !strings.Contains(got, `"level":"info"`) {
+		t.Fatalf("logfile missing level field; got: %s", got)
+	}
+}
+
+func TestNewLoggerErrorOnUnopenableFile(t *testing.T) {
+	t.Cleanup(resetGlobals)
+	// A directory cannot be opened with O_WRONLY|O_APPEND.
+	Verbose = false
+	Logfile = t.TempDir()
+
+	if _, _, err := newLogger(); err == nil {
+		t.Fatal("expected error when logfile path is a directory")
+	}
+}
+
+func resetGlobals() {
+	Verbose = false
+	Logfile = ""
+}


### PR DESCRIPTION
## Summary

Гигиенические улучшения по плану развития (3 пункта из 4 — миграция goreleaser отложена, см. ниже).

### Coverage 78.8% → 93.8%

`cmd/root_test.go` покрывает `newLogger`:
- verbose-level → Debug
- default → Info
- запись JSON в `--logfile`
- ошибка при невозможности открыть путь

### Dependabot

`.github/dependabot.yml` — еженедельные сгруппированные апдейты для `gomod` и `github-actions` (понедельник 06:00 МСК), префиксы коммитов `chore(deps)` / `chore(ci)`.

### Shell completions

`.goreleaser.yaml`:
- Генерация bash/zsh/fish через cobra (`go run . completion <shell>`) в `before:hooks`.
- Включение `completions/*` в архивы.
- Установка в формуле через `bash_completion.install` / `zsh_completion.install` / `fish_completion.install` — пользователи `brew install jtprogru/tap/go-monkill` получат tab-completion бесплатно.

### Что НЕ сделано и почему

Goreleaser warning `brews is being phased out in favor of homebrew_casks` я **не мигрировал**. Замена ключа меняет install path (`brew install` → `brew install --cask`) и каталог в tap (`Formula/` → `Casks/`), что сломает текущих пользователей. Подождём, пока upstream предложит binary-friendly путь миграции.

## Test plan

- [x] `task ci` — vet + lint + test зелёные, coverage 93.8%
- [x] `goreleaser release --snapshot` — completions попадают в архив, install-блок формулы корректный
- [ ] После merge: тег `v0.5.0` → проверить, что `brew install go-monkill && go-monkill <Tab>` работает

🤖 Generated with [Claude Code](https://claude.com/claude-code)