### PR TITLE
feat(watch): add --max-wait deadline flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Very simple utility that allows you to run the desired command or script as soon
 ## Features
 
 - Watch a PID and run an arbitrary command once the process exits.
+- Optional overall watch deadline via `--max-wait` (e.g. `30s`, `5m`).
 - Shell-style command parsing (single/double quotes, escapes) via [shlex](https://github.com/google/shlex).
 - Verbose debug logging of every poll cycle, watch duration and the command's exit code.
 - Optional JSON-formatted external log file (`--logfile`), parallel with text output to stderr.
@@ -46,6 +47,7 @@ go-monkill watch --pid=12345 --command="sh -c 'echo done >> /var/log/notify.log'
 | `--pid` | _required_ | PID to watch |
 | `--command` | _required_ | command to run after the process exits (shell-style quoting supported) |
 | `--timeout` | `250` | poll interval in milliseconds |
+| `--max-wait` | `0` | give up waiting after this duration (e.g. `30s`, `5m`); `0` = unlimited |
 | `-v`, `--verbose` | `false` | verbose (debug-level) output |
 | `--logfile` | _empty_ | path to a log file (JSON format); empty disables file logging |
 
@@ -56,6 +58,7 @@ go-monkill watch --pid=12345 --command="sh -c 'echo done >> /var/log/notify.log'
 | `0` | watched process exited and the user-command succeeded |
 | `1` | invalid input (PID, empty `--command`, parse error, waiter failure) |
 | _N_ | exit code of the user-command if it returned non-zero |
+| `124` | `--max-wait` elapsed before the watched process exited |
 | `130` | interrupted by `SIGINT`/`SIGTERM` before the watched process exited |
 
 ## Install

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/jtprogru/go-monkill/pkg/executor"
 	"github.com/jtprogru/go-monkill/pkg/waiter"
@@ -15,9 +16,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// exitCodeInterrupted is returned when the watcher is canceled before the
-// watched process terminates (matches the conventional 128+SIGINT shell code).
+// exitCodeInterrupted is returned when the watcher is canceled by a signal
+// before the watched process terminates (128+SIGINT, the shell convention).
 const exitCodeInterrupted = 130
+
+// exitCodeTimeout is returned when --max-wait elapses before the watched
+// process terminates (matches the convention used by timeout(1)).
+const exitCodeTimeout = 124
 
 var watchCmd = &cobra.Command{
 	Use:   "watch",
@@ -43,6 +48,7 @@ go-monkill watch --pid 12345 --command "ping jtprog.ru -c 4"
 			WatcherConfig.pid,
 			WatcherConfig.command,
 			WatcherConfig.timeout,
+			WatcherConfig.maxWait,
 			&waiter.Waiter{Logger: l},
 			&executor.Executor{Logger: l},
 			l,
@@ -62,6 +68,7 @@ var WatcherConfig struct {
 	pid     int
 	command string
 	timeout int64
+	maxWait time.Duration
 }
 
 func init() {
@@ -73,6 +80,12 @@ func init() {
 		"timeout",
 		defaultTimeOut,
 		"poll interval in milliseconds",
+	)
+	watchCmd.PersistentFlags().DurationVar(
+		&WatcherConfig.maxWait,
+		"max-wait",
+		0,
+		"give up waiting after this duration (e.g. 30s, 5m); 0 = unlimited",
 	)
 }
 
@@ -93,17 +106,24 @@ func watcher(
 	pid int,
 	command string,
 	timeout int64,
+	maxWait time.Duration,
 	w Waiter,
 	e Executor,
 	l *logrus.Logger,
 ) (int, error) {
-	l.Debugf("watcher start: pid=%d timeout=%dms command=%q", pid, timeout, command)
+	l.Debugf("watcher start: pid=%d timeout=%dms maxWait=%s command=%q", pid, timeout, maxWait, command)
 
 	if err := checkPid(pid, l); err != nil {
 		return 1, err
 	}
 	if command == "" {
 		return 1, errors.New("--command must not be empty")
+	}
+
+	if maxWait > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, maxWait)
+		defer cancel()
 	}
 
 	ch, err := w.Wait(ctx, pid, timeout)
@@ -116,6 +136,10 @@ func watcher(
 	case <-ch:
 		// proceed to run the command
 	case <-ctx.Done():
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			l.Warnf("max-wait %s elapsed before pid=%d exited; skipping command", maxWait, pid)
+			return exitCodeTimeout, ctx.Err()
+		}
 		l.Warnf("interrupted before pid=%d exited; skipping command", pid)
 		return exitCodeInterrupted, ctx.Err()
 	}

--- a/cmd/watch_test.go
+++ b/cmd/watch_test.go
@@ -79,7 +79,7 @@ func TestCheckPid(t *testing.T) {
 func TestWatcherHappyPath(t *testing.T) {
 	w := &fakeWaiter{fire: true}
 	e := &fakeExecutor{res: executor.Result{ExitCode: 0}}
-	code, err := watcher(context.Background(), 1234, "echo hi", 10, w, e, newTestLogger())
+	code, err := watcher(context.Background(), 1234, "echo hi", 10, 0, w, e, newTestLogger())
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -97,7 +97,7 @@ func TestWatcherHappyPath(t *testing.T) {
 func TestWatcherPropagatesExitCode(t *testing.T) {
 	w := &fakeWaiter{fire: true}
 	e := &fakeExecutor{res: executor.Result{ExitCode: 42, Err: errors.New("boom")}}
-	code, err := watcher(context.Background(), 1234, "echo hi", 10, w, e, newTestLogger())
+	code, err := watcher(context.Background(), 1234, "echo hi", 10, 0, w, e, newTestLogger())
 	if code != 42 {
 		t.Fatalf("exit code = %d, want 42", code)
 	}
@@ -107,7 +107,7 @@ func TestWatcherPropagatesExitCode(t *testing.T) {
 }
 
 func TestWatcherInvalidPID(t *testing.T) {
-	code, err := watcher(context.Background(), 0, "echo hi", 10, &fakeWaiter{}, &fakeExecutor{}, newTestLogger())
+	code, err := watcher(context.Background(), 0, "echo hi", 10, 0, &fakeWaiter{}, &fakeExecutor{}, newTestLogger())
 	if err == nil {
 		t.Fatal("expected error for invalid PID")
 	}
@@ -119,7 +119,7 @@ func TestWatcherInvalidPID(t *testing.T) {
 func TestWatcherEmptyCommand(t *testing.T) {
 	w := &fakeWaiter{fire: true}
 	e := &fakeExecutor{}
-	code, err := watcher(context.Background(), 1234, "", 10, w, e, newTestLogger())
+	code, err := watcher(context.Background(), 1234, "", 10, 0, w, e, newTestLogger())
 	if err == nil {
 		t.Fatal("expected error for empty command")
 	}
@@ -134,7 +134,7 @@ func TestWatcherEmptyCommand(t *testing.T) {
 func TestWatcherWaiterError(t *testing.T) {
 	w := &fakeWaiter{err: errors.New("waiter exploded")}
 	e := &fakeExecutor{}
-	code, err := watcher(context.Background(), 1234, "echo hi", 10, w, e, newTestLogger())
+	code, err := watcher(context.Background(), 1234, "echo hi", 10, 0, w, e, newTestLogger())
 	if err == nil {
 		t.Fatal("expected waiter error to bubble up")
 	}
@@ -157,7 +157,7 @@ func TestWatcherCancelledContext(t *testing.T) {
 		err  error
 	)
 	go func() {
-		code, err = watcher(ctx, 1234, "echo hi", 10, w, e, newTestLogger())
+		code, err = watcher(ctx, 1234, "echo hi", 10, 0, w, e, newTestLogger())
 		close(done)
 	}()
 
@@ -178,5 +178,35 @@ func TestWatcherCancelledContext(t *testing.T) {
 	}
 	if e.called {
 		t.Fatal("executor must not run when watcher is canceled")
+	}
+}
+
+func TestWatcherMaxWaitTimeout(t *testing.T) {
+	w := &fakeWaiter{block: true}
+	e := &fakeExecutor{}
+	code, err := watcher(context.Background(), 1234, "echo hi", 10, 50*time.Millisecond, w, e, newTestLogger())
+	if code != exitCodeTimeout {
+		t.Fatalf("exit code = %d, want %d", code, exitCodeTimeout)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected DeadlineExceeded, got %v", err)
+	}
+	if e.called {
+		t.Fatal("executor must not run when max-wait elapses")
+	}
+}
+
+func TestWatcherMaxWaitNotReached(t *testing.T) {
+	w := &fakeWaiter{fire: true}
+	e := &fakeExecutor{res: executor.Result{ExitCode: 0}}
+	code, err := watcher(context.Background(), 1234, "echo hi", 10, time.Hour, w, e, newTestLogger())
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	if !e.called {
+		t.Fatal("executor should run when max-wait did not expire")
 	}
 }


### PR DESCRIPTION
## Summary

Узкий, понятный таймаут на наблюдение целиком — следующий пункт из плана развития.

- `--max-wait <duration>` (default `0` = unlimited). Пример: `--max-wait=30s`, `--max-wait=5m`.
- При истечении дедлайна — exit code **124** (как у `timeout(1)`), пользовательская команда **не запускается**.
- Сигнальный путь не задет: SIGINT/SIGTERM → exit 130 как раньше. Два состояния различаются по `errors.Is(ctx.Err(), context.DeadlineExceeded)`.

### Что в README

- Новая фича в Features section.
- Строка в таблице флагов.
- Строка в таблице exit codes.

### Tests

- `TestWatcherMaxWaitTimeout` — блокирующий waiter + 50ms таймаут → 124 + DeadlineExceeded.
- `TestWatcherMaxWaitNotReached` — happy path с `1h` таймаутом не должен мешать выполнению команды.
- Все существующие тесты проброшены через новую сигнатуру `watcher(ctx, pid, cmd, timeout, maxWait, ...)`.

Coverage 93.8% → **94.2%**.

## Test plan

- [x] `task ci` зелёный
- [x] E2E: `sleep 30 & ; go-monkill watch --pid=$! --command="echo NEVER" --max-wait=500ms --verbose` → exit 124, команда не запущена
- [ ] После merge: тег v0.6.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)