### PR TITLE
release: v1.0.0 — switch Homebrew distribution from formula to cask

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -94,25 +94,30 @@ release:
   prerelease: auto
   name_template: "v{{ .Version }}"
 
-brews:
+homebrew_casks:
   - name: go-monkill
     repository:
       owner: jtprogru
       name: homebrew-tap
       branch: main
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
-    directory: Formula
     homepage: "https://github.com/jtprogru/go-monkill"
     description: "Run a command after a process with a given PID terminates"
-    license: "Apache-2.0"
+    binaries:
+      - go-monkill
+    completions:
+      bash: completions/go-monkill.bash
+      zsh: completions/go-monkill.zsh
+      fish: completions/go-monkill.fish
     commit_author:
       name: goreleaserbot
       email: bot@goreleaser.com
-    commit_msg_template: "chore(brew): bump {{ .ProjectName }} to {{ .Tag }}"
-    test: |
-      system "#{bin}/go-monkill", "version"
-    install: |
-      bin.install "go-monkill"
-      bash_completion.install "completions/go-monkill.bash" => "go-monkill"
-      zsh_completion.install  "completions/go-monkill.zsh"  => "_go-monkill"
-      fish_completion.install "completions/go-monkill.fish"
+    commit_msg_template: "chore(cask): bump {{ .ProjectName }} to {{ .Tag }}"
+    # Strip macOS quarantine xattr from the unsigned binary so Gatekeeper
+    # doesn't refuse to run it after `brew install --cask`.
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/go-monkill"]
+          end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-05-06
+
+First stable release. Marks the API and the CLI surface as stable; future
+breaking changes will bump the major version.
+
+### Changed
+- **Homebrew distribution**: switched from formula to cask via goreleaser's
+  `homebrew_casks` schema (the legacy `brews` is being phased out upstream).
+  The cask installs the same prebuilt binary, removes the macOS quarantine
+  xattr in a postflight hook so Gatekeeper doesn't refuse to launch the
+  unsigned binary, and ships shell completions.
+
+### Migration
+
+If you installed via `brew install jtprogru/tap/go-monkill` (formula),
+run once:
+
+```shell
+brew uninstall go-monkill
+brew install --cask jtprogru/tap/go-monkill
+```
+
+The formula `Formula/go-monkill.rb` will be removed from the tap shortly
+after v1.0.0 ships.
+
 ## [0.8.0] - 2026-05-06
 
 ### Added
@@ -109,7 +134,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Initial release on the new release infrastructure (handcrafted GitHub Actions
 workflow, `softprops/action-gh-release`).
 
-[Unreleased]: https://github.com/jtprogru/go-monkill/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/jtprogru/go-monkill/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/jtprogru/go-monkill/compare/v0.8.0...v1.0.0
 [0.8.0]: https://github.com/jtprogru/go-monkill/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/jtprogru/go-monkill/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/jtprogru/go-monkill/compare/v0.5.0...v0.6.0

--- a/README.md
+++ b/README.md
@@ -99,8 +99,16 @@ Hook failures are logged but do **not** override the child's exit code.
 
 ```shell
 brew tap jtprogru/tap
-brew install go-monkill
+brew install --cask go-monkill
 ```
+
+> **Migrating from v0.x?** The package was distributed as a Homebrew formula
+> until v0.8.x and is shipped as a cask starting with v1.0.0. Run:
+>
+> ```shell
+> brew uninstall go-monkill
+> brew install --cask jtprogru/tap/go-monkill
+> ```
 
 ### Pre-built binaries
 


### PR DESCRIPTION
## Summary

v1.0.0: маркируем API и CLI как стабильные. Главное изменение — **миграция Homebrew-дистрибуции с formula на cask** (goreleaser официально депрекейтит `brews`).

### Что меняется для пользователей

Команда установки:
```diff
- brew install jtprogru/tap/go-monkill
+ brew install --cask jtprogru/tap/go-monkill
```

### Зачем cask

- `brews` schema deprecated в goreleaser, замена — `homebrew_casks`.
- Cask поддерживает и macOS, и Linux (modern Homebrew on Linux supports casks).
- В `postflight` хуке снимаем `com.apple.quarantine` xattr — Gatekeeper не будет блокировать unsigned бинарь на первом запуске. С формулой это было невозможно.
- Shell completions встроены через `bash_completion` / `zsh_completion` / `fish_completion` стазы каска.

### Migration path для существующих пользователей

`v0.x` установки **не** мигрируются автоматически. Пользователю нужно один раз сделать:
```shell
brew uninstall go-monkill
brew install --cask jtprogru/tap/go-monkill
```

Документировано в README (баннер в Install секции) и CHANGELOG (Migration block).

### Tap cleanup

Старый `Formula/go-monkill.rb` останется в `jtprogru/homebrew-tap` после релиза. Удалю его отдельным PR в tap-репо сразу после публикации v1.0.0 — иначе во время transition window `brew install` пойдёт на формулу v0.8.0.

## Test plan

- [x] `goreleaser release --snapshot` — генерирует валидный `Casks/go-monkill.rb` без deprecation warnings (поправил `binary` → `binaries: [...]`).
- [x] Cask файл содержит правильные URL, sha256, completions, postflight xattr.
- [x] `task ci` зелёное.
- [ ] После merge: тег v1.0.0 → release pipeline → проверить что `Casks/go-monkill.rb` появился в tap.
- [ ] Follow-up в jtprogru/homebrew-tap: удаление `Formula/go-monkill.rb`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)