### PR TITLE
chore: explicitly drop Windows support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-05-06
+
+### Changed
+- Windows is **explicitly** declared unsupported. `main.go` now carries a
+  `//go:build linux || darwin` constraint, so `GOOS=windows go build`
+  fails with `build constraints exclude all Go files` instead of
+  pretending to produce a binary that has never worked anyway.
+- README documents the policy in the lead.
+
+This is a documentation/build-policy change only; no functional changes
+to the CLI surface or behaviour.
+
 ## [1.0.0] - 2026-05-06
 
 First stable release. Marks the API and the CLI surface as stable; future
@@ -134,7 +146,8 @@ after v1.0.0 ships.
 Initial release on the new release infrastructure (handcrafted GitHub Actions
 workflow, `softprops/action-gh-release`).
 
-[Unreleased]: https://github.com/jtprogru/go-monkill/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/jtprogru/go-monkill/compare/v1.0.1...HEAD
+[1.0.1]: https://github.com/jtprogru/go-monkill/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/jtprogru/go-monkill/compare/v0.8.0...v1.0.0
 [0.8.0]: https://github.com/jtprogru/go-monkill/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/jtprogru/go-monkill/compare/v0.6.0...v0.7.0

--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@
 
 Very simple utility that allows you to run the desired command or script as soon as a certain process with a known PID completes correctly or with an error.
 
+> **Supported platforms:** Linux and macOS only. Windows is **not** a target —
+> the build is explicitly fenced with `//go:build linux || darwin`, the
+> release pipeline only ships `linux/{amd64,arm64}` and `darwin/{amd64,arm64}`,
+> and the test suite assumes POSIX semantics (signals, `sleep`, `/proc`).
+
 ## Features
 
 - `watch` — observe one or more existing PIDs and run a command after they exit.

--- a/main.go
+++ b/main.go
@@ -1,7 +1,13 @@
+//go:build linux || darwin
+
 /*
-	Package go-monkill
-	A very simple utility that allows you to run the desired command or script
-	as soon as a certain process with a known PID completes correctly or with an error.
+Package go-monkill is a small utility that runs the desired command or
+script as soon as a process with a known PID terminates (subcommand
+"watch") or runs a child process and dispatches hooks based on its
+exit code (subcommand "run").
+
+Supported platforms: Linux and macOS. Windows is intentionally not
+supported — see README for details.
 */
 
 package main


### PR DESCRIPTION
## Summary

Делаю Windows-non-support явным. CI и так был только на `ubuntu-latest`, goreleaser строит только `linux/{amd64,arm64}` + `darwin/{amd64,arm64}`, тесты используют POSIX-only вещи (`sleep`-binary, реальные сигналы) — Windows никогда и не работал. Закрепляю это policy:

- `//go:build linux || darwin` на `main.go` — `GOOS=windows go build` теперь падает с `build constraints exclude all Go files` вместо тихого создания нерабочего бинаря.
- README: «Supported platforms» callout в самом начале.
- CHANGELOG: запись как v1.0.1 (documentation/build-policy only, никаких функциональных изменений).

## Verified

- `GOOS=windows go build .` → ошибка про build constraints (как и задумано).
- `GOOS=linux go build .` и `GOOS=darwin go build .` — собираются.
- `task ci` зелёное.

🤖 Generated with [Claude Code](https://claude.com/claude-code)