### PR TITLE
docs: drop platform-name callouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.1] - 2026-05-06
 
 ### Changed
-- Windows is **explicitly** declared unsupported. `main.go` now carries a
-  `//go:build linux || darwin` constraint, so `GOOS=windows go build`
-  fails with `build constraints exclude all Go files` instead of
-  pretending to produce a binary that has never worked anyway.
-- README documents the policy in the lead.
+- Build constraint `//go:build linux || darwin` added to `main.go`,
+  formalising the supported-platform set already enforced by the CI and
+  release matrix.
+- README documents the supported-platform policy in the lead.
 
-This is a documentation/build-policy change only; no functional changes
-to the CLI surface or behaviour.
+Documentation/build-policy change only; no functional changes to the CLI
+surface or behaviour.
 
 ## [1.0.0] - 2026-05-06
 

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@
 
 Very simple utility that allows you to run the desired command or script as soon as a certain process with a known PID completes correctly or with an error.
 
-> **Supported platforms:** Linux and macOS only. Windows is **not** a target —
-> the build is explicitly fenced with `//go:build linux || darwin`, the
-> release pipeline only ships `linux/{amd64,arm64}` and `darwin/{amd64,arm64}`,
-> and the test suite assumes POSIX semantics (signals, `sleep`, `/proc`).
+> **Supported platforms:** Linux and macOS. The build is fenced with
+> `//go:build linux || darwin`, the release pipeline ships
+> `linux/{amd64,arm64}` and `darwin/{amd64,arm64}`, and the test suite
+> assumes POSIX semantics (signals, `sleep`, `/proc`).
 
 ## Features
 

--- a/main.go
+++ b/main.go
@@ -6,8 +6,7 @@ script as soon as a process with a known PID terminates (subcommand
 "watch") or runs a child process and dispatches hooks based on its
 exit code (subcommand "run").
 
-Supported platforms: Linux and macOS. Windows is intentionally not
-supported — see README for details.
+Supported platforms: Linux and macOS.
 */
 
 package main


### PR DESCRIPTION
Убираю любые упоминания неподдерживаемой платформы из текста (CHANGELOG v1.0.1, README callout, doc-comment в main.go).

Build constraint `//go:build linux || darwin` остаётся — он перечисляет **поддерживаемые** ОС, не упоминая исключённые.

Никаких функциональных изменений.

🤖 Generated with [Claude Code](https://claude.com/claude-code)